### PR TITLE
Allow loading datacenters from a custom location

### DIFF
--- a/lib/ipcat.rb
+++ b/lib/ipcat.rb
@@ -37,11 +37,11 @@ class IPCat
       self.ranges.freeze
     end
 
-    def load!
+    def load!(path=nil)
       reset_ranges!
       # NB: loading an array of marshaled ruby objects takes ~15ms;
       # versus ~100ms to load a CSV file
-      path = File.join(File.dirname(__FILE__), '..', 'data', 'datacenters')
+      path ||= File.join(File.dirname(__FILE__), '..', 'data', 'datacenters')
       @ranges = Marshal.load(File.read(path))
       @ranges.each(&:freeze)
       @ranges.freeze

--- a/lib/ipcat.rb
+++ b/lib/ipcat.rb
@@ -10,6 +10,7 @@ require 'ipcat/version'
 class IPCat
   class << self
     def datacenter?(ip)
+      load! unless @loaded
       bsearch(ip_to_integer(ip))
     end
     alias_method :classify, :datacenter?
@@ -35,6 +36,8 @@ class IPCat
         self.ranges << IPRange.new(first, last, name, url).freeze
       end
       self.ranges.freeze
+
+      @loaded = true
     end
 
     def load!(path=nil)
@@ -45,6 +48,8 @@ class IPCat
       @ranges = Marshal.load(File.read(path))
       @ranges.each(&:freeze)
       @ranges.freeze
+
+      @loaded = true
     rescue
       load_csv!
     end
@@ -65,6 +70,3 @@ class IPCat
     end
   end
 end
-
-# Load dataset
-IPCat.load!


### PR DESCRIPTION
This is to allow updating datacenters (stored in a different location) without having to update the gem. This PR has two changes:
 - allow specifying custom datacenter path in load! method
 - load datacenters on the first request instead of loading it when loading the gem
